### PR TITLE
Use session as global variable, x35 times faster.

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -26,8 +26,9 @@ type LabelResult struct {
 }
 
 var (
-	graph  *tf.Graph
-	labels []string
+	graphModel   *tf.Graph
+	sessionModel *tf.Session
+	labels       []string
 )
 
 func main() {
@@ -47,10 +48,17 @@ func loadModel() error {
 	if err != nil {
 		return err
 	}
-	graph = tf.NewGraph()
-	if err := graph.Import(model, ""); err != nil {
+	graphModel = tf.NewGraph()
+	if err := graphModel.Import(model, ""); err != nil {
 		return err
 	}
+
+	// Run inference
+	sessionModel, err = tf.NewSession(graphModel, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Load labels
 	labelsFile, err := os.Open("/model/imagenet_comp_graph_label_strings.txt")
 	if err != nil {
@@ -90,18 +98,12 @@ func recognizeHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Param
 		return
 	}
 
-	// Run inference
-	session, err := tf.NewSession(graph, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer session.Close()
-	output, err := session.Run(
+	output, err := sessionModel.Run(
 		map[tf.Output]*tf.Tensor{
-			graph.Operation("input").Output(0): tensor,
+			graphModel.Operation("input").Output(0): tensor,
 		},
 		[]tf.Output{
-			graph.Operation("output").Output(0),
+			graphModel.Operation("output").Output(0),
 		},
 		nil)
 	if err != nil {

--- a/api/main.go
+++ b/api/main.go
@@ -53,7 +53,6 @@ func loadModel() error {
 		return err
 	}
 
-	// Run inference
 	sessionModel, err = tf.NewSession(graphModel, nil)
 	if err != nil {
 		log.Fatal(err)
@@ -98,6 +97,7 @@ func recognizeHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Param
 		return
 	}
 
+	// Run inference
 	output, err := sessionModel.Run(
 		map[tf.Output]*tf.Tensor{
 			graphModel.Operation("input").Output(0): tensor,


### PR DESCRIPTION
TensorFlow abandon device information when all of sessions are gone. So detecting devices will be done in each HTTP request. This change put sessionModel on global scope to keep device information. This may get dramatic performance up.

In the original source code, it works with only 2 fps on my Jetson TX 2. With this change, I could see 60-70 fps.